### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,11 @@ if (NOT IMGUI_DEMO)
     target_compile_definitions (imgui PUBLIC -DIMGUI_DISABLE_DEMO_WINDOWS=1)
 endif ()
 
-if (IMGUI_IMPL_SDL)
+if (IMGUI_IMPL_SDL AND NOT SDL2_LIBDIR)
+    message(FATAL_ERROR "SDL requested but not found")
+endif ()
+
+if (IMGUI_IMPL_SDL AND SDL2_LIBDIR)
     include (examples/imgui_impl_sdl.cmake)
 endif ()
 if (IMGUI_IMPL_METAL)


### PR DESCRIPTION
SDL build defaults to ON but can fail to be detected at build.  examples/imgui_impl_sdl.cmake will fail as a result.  

Option comment implies the build would succeed only if detected.  Make it a fatal error for now.


```
[ 57%] Building CXX object CMakeFiles/imgui-sdl.dir/examples/imgui_impl_sdl.cpp.o
/tmp/build/imgui-cmake/examples/imgui_impl_sdl.cpp:51:17: fatal error: SDL.h: No such file or directory
 #include <SDL.h>
                 ^
compilation terminated.
[ 71%] Built target imgui_example_glut_opengl2
[ 85%] Built target imgui_example_null
make[2]: *** [CMakeFiles/imgui-sdl.dir/examples/imgui_impl_sdl.cpp.o] Error 1
make[1]: *** [CMakeFiles/imgui-sdl.dir/all] Error 2
make: *** [all] Error 2
$
```